### PR TITLE
DBT-1411 Edit report by blocks

### DIFF
--- a/core/langs/ca.json
+++ b/core/langs/ca.json
@@ -39,6 +39,8 @@
     "total-records": "Registres totals",
     "total-page": "Pàgines totals",
     "of": "de",
-    "here": "aquí"
+    "here": "aquí",
+    "copy": "Copiar",
+    "copy-success": "Copiat!"
   }
 }

--- a/core/langs/en.json
+++ b/core/langs/en.json
@@ -38,6 +38,8 @@
     "leave": "Leave",
     "total-records": "Total Records",
     "total-page": "Total Pages",
+    "copy": "Copy",
+    "copy-success": "Copied!",
     "of": "of",
     "here": "here"
   }

--- a/core/langs/es.json
+++ b/core/langs/es.json
@@ -39,6 +39,8 @@
     "total-records": "Registros totales",
     "total-page": "Páginas totales",
     "of": "de",
-    "here": "aquí"
+    "here": "aquí",
+    "copy": "Copiar",
+    "copy-success": "¡Copiado!"
   }
 }

--- a/core/langs/pt.json
+++ b/core/langs/pt.json
@@ -39,6 +39,8 @@
     "total-records": "Registros Totais",
     "total-page": "Páginas Totais",
     "of": "de",
-    "here": "aqui"
+    "here": "aqui",
+    "copy": "Copiar",
+    "copy-success": "Copiado!"
   }
 }

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -56,15 +56,8 @@ export const MediaDevicesMock = {
   enumerateDevices: jest.fn().mockReturnValue([]),
 };
 
-export const MockClipBoard = {
-  writeText: jest.fn(),
-};
-
 Object.defineProperty(global.navigator, "mediaDevices", {
   value: MediaDevicesMock,
-});
-Object.defineProperty(global.navigator, "clipboard", {
-  value: MockClipBoard,
 });
 
 // Window

--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -56,8 +56,15 @@ export const MediaDevicesMock = {
   enumerateDevices: jest.fn().mockReturnValue([]),
 };
 
+export const MockClipBoard = {
+  writeText: jest.fn(),
+};
+
 Object.defineProperty(global.navigator, "mediaDevices", {
   value: MediaDevicesMock,
+});
+Object.defineProperty(global.navigator, "clipboard", {
+  value: MockClipBoard,
 });
 
 // Window

--- a/modules/auth/saas/saas-auth.test.tsx
+++ b/modules/auth/saas/saas-auth.test.tsx
@@ -8,7 +8,7 @@ import { AuthService } from "@/core/module/services.types";
 import { faker } from "@faker-js/faker";
 import { RouterMock, ToastMock, TranslationMock } from "@/jest-setup";
 import MessageHandler from "@/core/message-handler";
-import React from "react";
+import React, { act } from "react";
 import { login } from "@/resources/tests/test.utils";
 
 const getInput = (container: HTMLElement, inputName: string) => {
@@ -447,7 +447,7 @@ describe("===== SAAS LOGIN =====", () => {
       await userEvent.type(passwordInput, password);
       await userEvent.type(confirmPassword, password);
 
-      screen.getByTestId("updateSettings").click();
+      act(() => screen.getByTestId("updateSettings").click());
 
       await waitFor(() =>
         expect(ToastMock.error).toHaveBeenCalledWith("Error Updating the user")

--- a/modules/auth/saas/saas-auth.test.tsx
+++ b/modules/auth/saas/saas-auth.test.tsx
@@ -68,7 +68,7 @@ describe("===== SAAS LOGIN =====", () => {
     it("Login Fields are required", async () => {
       render(<Login />);
 
-      screen.getByTestId("submitLogin").click();
+      act(() => screen.getByTestId("submitLogin").click());
 
       await waitFor(() => {
         expect(screen.getByText("auth.email-required")).toBeInTheDocument();
@@ -86,7 +86,7 @@ describe("===== SAAS LOGIN =====", () => {
 
       // Makes the form dirty
 
-      screen.getByTestId("submitLogin").click();
+      act(() => screen.getByTestId("submitLogin").click());
       await userEvent.type(emailInput, "wrong-email");
       await userEvent.type(passwordInput, "123");
 
@@ -114,7 +114,7 @@ describe("===== SAAS LOGIN =====", () => {
         faker.internet.password({ length: 10 })
       );
 
-      screen.getByTestId("submitLogin").click();
+      act(() => screen.getByTestId("submitLogin").click());
 
       await waitFor(() => expect(spy).toHaveBeenCalledWith("/app/dashboard"));
     });
@@ -136,7 +136,7 @@ describe("===== SAAS LOGIN =====", () => {
         faker.internet.password({ length: 10 })
       );
 
-      screen.getByTestId("submitLogin").click();
+      act(() => screen.getByTestId("submitLogin").click());
 
       await waitFor(() =>
         expect(ToastMock.error).toHaveBeenCalledWith("User Don`t exists")
@@ -167,7 +167,7 @@ describe("===== SAAS LOGIN =====", () => {
     it("Reset Password Fields are required", async () => {
       render(<ResetPassword />);
 
-      screen.getByTestId("resetPassword").click();
+      act(() => screen.getByTestId("resetPassword").click());
 
       await waitFor(() => {
         expect(screen.getByText("auth.email-required")).toBeInTheDocument();
@@ -182,7 +182,7 @@ describe("===== SAAS LOGIN =====", () => {
       ) as Element;
 
       // Makes the form dirty
-      screen.getByTestId("resetPassword").click();
+      act(() => screen.getByTestId("resetPassword").click());
 
       await userEvent.type(emailInput, "wrong-email");
 
@@ -204,7 +204,7 @@ describe("===== SAAS LOGIN =====", () => {
 
       await userEvent.type(emailInput, faker.internet.email());
 
-      screen.getByTestId("resetPassword").click();
+      act(() => screen.getByTestId("resetPassword").click());
 
       await waitFor(() => {
         expect(spy).toHaveBeenCalledWith("/auth/login");
@@ -225,7 +225,7 @@ describe("===== SAAS LOGIN =====", () => {
 
       await userEvent.type(emailInput, faker.internet.email());
 
-      screen.getByTestId("resetPassword").click();
+      act(() => screen.getByTestId("resetPassword").click());
       await waitFor(() =>
         expect(ToastMock.error).toHaveBeenCalledWith("Email Not Found")
       );
@@ -277,7 +277,7 @@ describe("===== SAAS LOGIN =====", () => {
     it("Register Fields are required", async () => {
       render(<Register />);
 
-      screen.getByTestId("submitRegistration").click();
+      act(() => screen.getByTestId("submitRegistration").click());
 
       await waitFor(() => screen.getByText("auth.email-required"));
 
@@ -295,7 +295,7 @@ describe("===== SAAS LOGIN =====", () => {
       const confirmPassword = getInput(container, "confirm_password");
 
       // Makes the form dirty
-      screen.getByTestId("submitRegistration").click();
+      act(() => screen.getByTestId("submitRegistration").click());
 
       await userEvent.type(emailInput, "wrong-email");
       await userEvent.type(passwordInput, "123");
@@ -321,7 +321,7 @@ describe("===== SAAS LOGIN =====", () => {
       await userEvent.type(passwordInput, password);
       await userEvent.type(confirmPassword, password);
 
-      screen.getByTestId("submitRegistration").click();
+      act(() => screen.getByTestId("submitRegistration").click());
 
       await waitFor(() => expect(spy).toHaveBeenCalledWith("/auth/login"));
     });
@@ -342,7 +342,7 @@ describe("===== SAAS LOGIN =====", () => {
       await userEvent.type(passwordInput, password);
       await userEvent.type(confirmPassword, password);
 
-      screen.getByTestId("submitRegistration").click();
+      act(() => screen.getByTestId("submitRegistration").click());
       await waitFor(() =>
         expect(ToastMock.error).toHaveBeenCalledWith("User already registered")
       );
@@ -383,7 +383,7 @@ describe("===== SAAS LOGIN =====", () => {
     it("Update Settings Fields are required", async () => {
       render(<Settings />);
 
-      screen.getByTestId("updateSettings").click();
+      act(() => screen.getByTestId("updateSettings").click());
 
       await waitFor(() => screen.getByText("auth.email-required"));
 
@@ -401,7 +401,7 @@ describe("===== SAAS LOGIN =====", () => {
       const confirmPassword = getInput(container, "confirm_password");
 
       // Makes the form dirty
-      screen.getByTestId("updateSettings").click();
+      act(() => screen.getByTestId("updateSettings").click());
 
       await userEvent.type(emailInput, "wrong-email");
       await userEvent.type(passwordInput, "123");
@@ -426,7 +426,7 @@ describe("===== SAAS LOGIN =====", () => {
       await userEvent.type(passwordInput, password);
       await userEvent.type(confirmPassword, password);
 
-      screen.getByTestId("updateSettings").click();
+      act(() => screen.getByTestId("updateSettings").click());
       await waitFor(() => expect(ToastMock.success).toHaveBeenCalledTimes(1));
     });
 

--- a/modules/recording/recording/dashboard.tsx
+++ b/modules/recording/recording/dashboard.tsx
@@ -89,7 +89,7 @@ const Dashboard = () => {
       messageHandler.info(t("recording.stopped"));
       setRecordingState("inactive");
       stopVisualization();
-      router.push({
+      void router.push({
         pathname: "/app/recording",
         query: { audioUrl: audioUrl },
       });
@@ -190,14 +190,14 @@ const Dashboard = () => {
             <RecordButton
               recordingState={recordingState}
               audioLevel={audioLevel}
-              onClick={toggleRecording}
+              onClick={() => void toggleRecording()}
               statusMessage={getStatusMessage()}
               disabled={!hasTemplates}
             />
             {recordingState !== "inactive" && (
               <button
                 className={dash_styles.stopButton}
-                onClick={stopRecording}
+                onClick={() => void stopRecording()}
               >
                 <FaStop size={20} style={{ marginRight: "10px" }} />
                 {t("recording.stop")}

--- a/modules/recording/recording/recording.test.tsx
+++ b/modules/recording/recording/recording.test.tsx
@@ -1,6 +1,10 @@
 import "@testing-library/jest-dom";
 import {
+  findByText,
   fireEvent,
+  getByTestId,
+  getByText,
+  queryByTestId,
   render,
   screen,
   waitFor,
@@ -18,6 +22,7 @@ import { faker } from "@faker-js/faker";
 import {
   FetchMock,
   MediaDevicesMock,
+  MockClipBoard,
   RouterMock,
   ToastMock,
 } from "@/jest-setup";
@@ -37,7 +42,7 @@ describe("===== RECORDING AUDIO =====", () => {
   beforeAll(() => {
     genesisService = GlobalCore.manager.getComponent(
       "service",
-      "medical-api",
+      "medical-api"
     ) as MedicalTranscription;
   });
 
@@ -77,7 +82,7 @@ describe("===== RECORDING AUDIO =====", () => {
       act(() => recordButton.click());
 
       expect(ToastMock.error).toHaveBeenCalledWith(
-        "recording.permission-required",
+        "recording.permission-required"
       );
     });
 
@@ -127,7 +132,7 @@ describe("===== RECORDING AUDIO =====", () => {
 
       await userEvent.upload(
         input,
-        Seed.new().file({ name: "audio.mp3", type: "audio/mp3" }),
+        Seed.new().file({ name: "audio.mp3", type: "audio/mp3" })
       );
 
       await waitFor(() => screen.getByText("audio.mp3"));
@@ -139,7 +144,7 @@ describe("===== RECORDING AUDIO =====", () => {
 
       await userEvent.upload(
         input,
-        Seed.new().file({ name: "image.mp3", type: "image/mp3" }),
+        Seed.new().file({ name: "image.mp3", type: "image/mp3" })
       );
 
       expect(screen.queryByText("image.png")).not.toBeInTheDocument();
@@ -167,7 +172,7 @@ describe("===== RECORDING AUDIO =====", () => {
       expect(screen.getByText("recording.upload-files")).toBeDisabled();
       await userEvent.upload(
         input,
-        Seed.new().file({ name: "audio.png", type: "audio/png" }),
+        Seed.new().file({ name: "audio.png", type: "audio/png" })
       );
 
       expect(screen.getByText("recording.upload-files")).not.toBeDisabled();
@@ -189,7 +194,7 @@ describe("===== RECORDING AUDIO =====", () => {
       jest
         .spyOn(FetchMock, "blob")
         .mockResolvedValueOnce(
-          Seed.new().file({ name: "audio.mp3", type: "audio/mp3" }),
+          Seed.new().file({ name: "audio.mp3", type: "audio/mp3" })
         );
     });
     beforeEach(() => {
@@ -241,7 +246,7 @@ describe("===== RECORDING AUDIO =====", () => {
       act(() => submitButton.click());
       await waitFor(() => {
         expect(ToastMock.error).toHaveBeenCalledWith(
-          "recording.error-no-audio-file",
+          "recording.error-no-audio-file"
         );
         expect(RouterMock.replace).toHaveBeenCalledWith("/app/dashboard");
       });
@@ -301,12 +306,7 @@ describe("===== RECORDING AUDIO =====", () => {
     const getRecordingTab = () => screen.getByText("recording.report");
     const getTranscriptionTab = () =>
       screen.getByText("recording.transcription");
-    const getEditButton = () =>
-      screen.queryByText("common.edit") as HTMLButtonElement;
-    const getSaveButton = () =>
-      screen.queryByText("common.save") as HTMLButtonElement;
-    const getCancelButton = () =>
-      screen.queryByText("common.cancel") as HTMLButtonElement;
+
     const getDownloadButton = () => screen.getByText("recording.download");
 
     const getNewRecordingButton = () =>
@@ -339,8 +339,6 @@ describe("===== RECORDING AUDIO =====", () => {
       expect(getRecordingTab()).toBeInTheDocument();
       expect(getTranscriptionTab()).toBeInTheDocument();
       expect(getNewRecordingButton()).toBeInTheDocument();
-      expect(getEditButton()).toBeInTheDocument();
-      expect(getSaveButton()).not.toBeInTheDocument();
       expect(getDownloadButton()).toBeInTheDocument();
       expect(getReplyButton()).toBeInTheDocument();
     });
@@ -365,7 +363,7 @@ describe("===== RECORDING AUDIO =====", () => {
       });
       // Transcription is hidden
       expect(
-        screen.getByText(report.transcription[0]).closest(".hiddenContent"),
+        screen.getByText(report.transcription[0]).closest(".hiddenContent")
       ).toBeTruthy();
     });
 
@@ -383,7 +381,7 @@ describe("===== RECORDING AUDIO =====", () => {
       expect(
         screen
           .getByText(Object.values(report.report)[0])
-          .closest(".hiddenContent"),
+          .closest(".hiddenContent")
       ).toBeTruthy();
     });
 
@@ -416,65 +414,81 @@ describe("===== RECORDING AUDIO =====", () => {
       // TODO: Add alert message here that he needs to confirm or will lose the audio
       expect(RouterMock.push).toHaveBeenCalledWith("/app/dashboard");
     });
-    it.todo("URL changes fires the not saved audio warning");
+
+    it("Copy the report content block", async () => {
+      render(<Report />);
+      const [title, content] = Object.entries(report.report)[0];
+      const div = (await screen.findByText(title)).closest(
+        ".editable-wrapper"
+      ) as HTMLElement;
+
+      expect(getByText(div, content)).toBeInTheDocument();
+
+      act(() => getByTestId(div, "editable.copy").click());
+      expect(MockClipBoard.writeText).toHaveBeenCalledWith(content);
+    });
 
     it("Update the editor also updates the preview", async () => {
       const user = userEvent.setup();
 
       const { container } = render(<Report />);
-      act(() => getEditButton().click());
+      const [title, content] = Object.entries(report.report)[0];
+      const div = (await screen.findByText(title)).closest(
+        ".editable-wrapper"
+      ) as HTMLElement;
 
+      expect(getByText(div, content)).toBeInTheDocument();
+
+      act(() => getByTestId(div, "editable.edit").click());
       await waitFor(() => container.querySelector(".ql-editor"));
-      const qlEditor = container.querySelector(".ql-editor") as Element;
-      // Get first title
-      const firstTitle = qlEditor.querySelector("h3") as Element;
-      console.log(firstTitle.innerHTML);
+      const qlEditor = container.querySelector(".ql-editor") as HTMLElement;
+      // Get first content
+      const firstTitle = qlEditor.querySelector("p") as Element;
       expect(firstTitle).toBeTruthy();
 
-      // act(() => (firstTitle.innerHTML = "My new title"));
-      // await act(() => fireEvent.change(qlEditor, qlEditor.innerHTML));
-
       await act(async () => {
-        await user.type(firstTitle, " My new title");
+        await user.type(firstTitle, "My new text");
       });
-
-      console.log(firstTitle.innerHTML);
 
       act(() => {
-        getSaveButton().click();
+        getByTestId(div, "editable.save").click();
       });
 
-      await waitFor(() => screen.getByText(/My new title/i).tagName === "H2");
-      expect(screen.getByText(/My new title/i).tagName).toEqual("H2");
+      await waitFor(() => screen.getByText(/My new text/i).tagName === "p");
+      expect(screen.getByText(/My new text/i).tagName).toEqual("P");
 
-      expect(getSaveButton()).not.toBeInTheDocument();
-      expect(getEditButton()).toBeInTheDocument();
+      expect(queryByTestId(div, "editable.save")).not.toBeInTheDocument();
+      expect(queryByTestId(div, "editable.edit")).toBeInTheDocument();
     });
 
     it("Cancel the editor don't update the preview", async () => {
       const { container } = render(<Report />);
-      act(() => getEditButton().click());
+      const [title, content] = Object.entries(report.report)[0];
+      const div = (await screen.findByText(title)).closest(
+        ".editable-wrapper"
+      ) as HTMLElement;
+
+      act(() => getByTestId(div, "editable.edit").click());
 
       await waitFor(() => container.querySelector(".ql-editor"));
 
-      expect(getCancelButton()).toBeInTheDocument();
+      expect(getByTestId(div, "editable.cancel")).toBeInTheDocument();
 
       const qlEditor = container.querySelector(".ql-editor") as Element;
-      // Get first title
-      const firstTitle = qlEditor.querySelector("h3") as Element;
-      expect(firstTitle).toBeTruthy();
-
-      firstTitle.innerHTML = "My new title";
+      // Get first content
+      const editorContent = qlEditor.querySelector("p") as Element;
+      expect(editorContent).toBeTruthy();
+      editorContent.innerHTML = "My new Content";
       await act(() => fireEvent.change(qlEditor, qlEditor.innerHTML));
-
       act(() => {
-        getCancelButton().click();
+        getByTestId(div, "editable.cancel").click();
       });
-      // await waitForElementToBeRemoved(() => screen.getByText("My new title"));
-      expect(screen.queryByText("My new title")).not.toBeInTheDocument();
 
-      expect(getSaveButton()).not.toBeInTheDocument();
-      expect(getEditButton()).toBeInTheDocument();
+      await waitFor(() => getByTestId(div, "editable.edit"));
+      expect(screen.queryByText(content)).toBeInTheDocument();
+
+      expect(queryByTestId(div, "editable.save")).not.toBeInTheDocument();
+      expect(queryByTestId(div, "editable.edit")).toBeInTheDocument();
     });
 
     it("Download Audio", async () => {
@@ -507,7 +521,7 @@ describe("===== RECORDING AUDIO =====", () => {
       getDownloadButton().click();
 
       const button = await screen.findByText(
-        "recording.download-transcription",
+        "recording.download-transcription"
       );
 
       act(() => button.click());
@@ -520,7 +534,7 @@ describe("===== RECORDING AUDIO =====", () => {
       getDownloadButton().click();
 
       const button = await screen.findByText(
-        "recording.download-transcription",
+        "recording.download-transcription"
       );
 
       act(() => button.click());
@@ -538,7 +552,7 @@ describe("===== RECORDING AUDIO =====", () => {
 
       const bar = screen.getByTestId("time-bar");
       const segments = bar.querySelectorAll(
-        ".progressSegment",
+        ".progressSegment"
       ) as unknown as HTMLDivElement[];
 
       expect(segments[0].style.width).toEqual(transcriptionWidth + "%");
@@ -546,7 +560,7 @@ describe("===== RECORDING AUDIO =====", () => {
 
       const totalTime = screen.getByText("recording.total-time");
       expect(totalTime.parentElement?.textContent).toContain(
-        (total / 1000).toString(),
+        (total / 1000).toString()
       );
     });
   });

--- a/modules/recording/recording/report.tsx
+++ b/modules/recording/recording/report.tsx
@@ -9,14 +9,16 @@ import { useTranslation } from "react-i18next";
 import Button from "@/resources/containers/button";
 import Download from "./libs/download";
 import { ProgressBar } from "@/resources/containers/progress-bar";
+import ViewContentEditable from "@/resources/containers/view-content-editable";
 
 const Report = () => {
   const router = useRouter();
   const { t } = useTranslation();
   const { audioUrl } = router.query;
   const [activeTab, setActiveTab] = useState("report");
-  const [reportContent, setReportContent] = useState({});
-  const [editedReportContent, setEditedReportContent] = useState({});
+  const [reportContent, setReportContent] = useState(
+    {} as Record<string, string>
+  );
   const [transcriptionContent, setTranscriptionContent] = useState<string[]>(
     []
   );
@@ -44,20 +46,7 @@ const Report = () => {
   }, [router]);
 
   const handleTabChange = (tab: string) => {
-    console.log({ tab });
     setActiveTab(tab);
-  };
-
-  const openEditor = () => {
-    setEditedReportContent(reportContent);
-    setIsEditing(true);
-  };
-  const closeEditor = () => {
-    setIsEditing(false);
-  };
-  const saveEditor = () => {
-    setIsEditing(false);
-    setReportContent(editedReportContent);
   };
 
   // TODO: Refactor as a resource
@@ -119,13 +108,19 @@ const Report = () => {
               : report_styles.hiddenContent
           }
         >
-          {isEditing ? (
-            <Editor
-              content={reportContent}
-              onContentChange={(content) => setEditedReportContent(content)}
-            />
-          ) : (
-            <ViewContent content={reportContent} />
+          {Object.entries(reportContent).map(
+            ([title, content], index: number) => {
+              return (
+                <ViewContentEditable
+                  key={index}
+                  title={title}
+                  content={content}
+                  onEdit={(title, content) =>
+                    setReportContent({ ...reportContent, [title]: content })
+                  }
+                />
+              );
+            }
           )}
         </div>
         <div
@@ -141,18 +136,18 @@ const Report = () => {
     );
   };
 
-  const handleDownload = (type: string) => {
+  const handleDownload = async (type: string) => {
     switch (type) {
       case "audio":
         if (audioUrl) {
-          Download.downloadAudio(audioUrl as string);
+          await Download.downloadAudio(audioUrl as string);
         }
         break;
       case "report":
-        Download.downloadReport(reportContent);
+        await Download.downloadReport(reportContent);
         break;
       case "transcription":
-        Download.downloadTranscription(transcriptionContent);
+        await Download.downloadTranscription(transcriptionContent);
         break;
     }
   };
@@ -176,13 +171,13 @@ const Report = () => {
         </button>
         {isDownloadOpen && (
           <div className={report_styles.downloadDropdown}>
-            <button onClick={() => handleDownload("audio")}>
+            <button onClick={() => void handleDownload("audio")}>
               {t("recording.download-audio")}
             </button>
-            <button onClick={() => handleDownload("report")}>
+            <button onClick={() => void handleDownload("report")}>
               {t("recording.download-report")}
             </button>
-            <button onClick={() => handleDownload("transcription")}>
+            <button onClick={() => void handleDownload("transcription")}>
               {t("recording.download-transcription")}
             </button>
           </div>
@@ -259,34 +254,6 @@ const Report = () => {
             : t("recording.replay-audio")}
         </Button>
         <div className="flex" style={{ gap: "8px" }}>
-          {activeTab === "report" &&
-            (!isEditing ? (
-              <Button
-                onClick={openEditor}
-                variant={"secondary"}
-                className={report_styles.editButton}
-              >
-                {t("common.edit")}
-              </Button>
-            ) : (
-              <>
-                <Button
-                  onClick={saveEditor}
-                  variant={"secondary"}
-                  className={report_styles.saveButton}
-                >
-                  {t("common.save")}
-                </Button>
-                <Button
-                  onClick={closeEditor}
-                  variant={"secondary"}
-                  className={report_styles.saveButton}
-                >
-                  {t("common.cancel")}
-                </Button>
-              </>
-            ))}
-
           <Button
             onClick={() => void router.push("/app/dashboard")}
             variant="primary"

--- a/modules/templates/templates/template-detail.tsx
+++ b/modules/templates/templates/template-detail.tsx
@@ -62,7 +62,7 @@ const TemplateDetail = () => {
   });
   const [isLoading, setIsLoading] = useState(true);
   const [fieldModalConfig, setFieldModalConfig] = useState<FieldData | null>(
-    null,
+    null
   );
 
   const fetchTemplate = useCallback(
@@ -85,7 +85,7 @@ const TemplateDetail = () => {
         setIsLoading(false);
       }
     },
-    [id, templateService, t],
+    [id, templateService, t]
   );
 
   useEffect(() => {
@@ -144,7 +144,7 @@ const TemplateDetail = () => {
     try {
       const updatedTemplate = await templateService.updateTemplate(
         template.id,
-        { fields: updatedFields },
+        { fields: updatedFields }
       );
       if (updatedTemplate) {
         setTemplate(updatedTemplate);
@@ -166,7 +166,7 @@ const TemplateDetail = () => {
   const handleInputChange = (
     fieldKey: string,
     property: string,
-    value: string,
+    value: string
   ) => {
     setEditedValues((prev) => ({
       ...prev,
@@ -200,7 +200,7 @@ const TemplateDetail = () => {
     try {
       const updatedTemplate = await templateService.updateTemplate(
         template.id,
-        { fields: updatedFields },
+        { fields: updatedFields }
       );
       if (updatedTemplate) {
         setTemplate(updatedTemplate);
@@ -219,13 +219,13 @@ const TemplateDetail = () => {
   };
 
   function isNumberFieldConfig(
-    config: FieldConfig,
+    config: FieldConfig
   ): config is NumberFieldConfig {
     return "maxValue" in config;
   }
 
   function isSelectFieldConfig(
-    config: FieldConfig,
+    config: FieldConfig
   ): config is SelectFieldConfig {
     return "options" in config;
   }
@@ -295,7 +295,7 @@ const TemplateDetail = () => {
           {editingField === record.key ? (
             <div style={{ display: "flex", gap: "3vh" }}>
               <IconButton
-                onClick={() => handleSave(record.key)}
+                onClick={() => void handleSave(record.key)}
                 size="small"
                 testId="template-detail.save-field"
               >
@@ -309,7 +309,7 @@ const TemplateDetail = () => {
                 <FaTimes style={{ color: "var(--danger)" }} />
               </IconButton>
               {["number", "select", "multiselect"].includes(
-                editedValues[record.key]?.type,
+                editedValues[record.key]?.type
               ) && (
                 <IconButton
                   onClick={() => {
@@ -324,7 +324,7 @@ const TemplateDetail = () => {
                       configToUse = { maxValue: fieldConfig.maxValue };
                     } else if (
                       [TYPE_OPTIONS.SELECT, TYPE_OPTIONS.MULTISELECT].includes(
-                        editedValues[record.key]?.type,
+                        editedValues[record.key]?.type
                       ) &&
                       fieldConfig &&
                       isSelectFieldConfig(fieldConfig)
@@ -422,7 +422,7 @@ const TemplateDetail = () => {
       <DeleteConfirmation
         isOpen={!!fieldToDelete}
         onRequestClose={() => setFieldToDelete(null)}
-        onConfirm={confirmDelete}
+        onConfirm={() => void confirmDelete()}
         testId="template-detail.delete-confirmation"
       />
 

--- a/modules/templates/templates/templates.test.tsx
+++ b/modules/templates/templates/templates.test.tsx
@@ -29,7 +29,6 @@ describe("===== TEMPLATES =====", () => {
       expect(screen.getByTestId("templates.title")).toBeInTheDocument();
       expect(screen.getByTestId("templates.new-template")).toBeInTheDocument();
       expect(screen.queryByText("templates.table")).not.toBeInTheDocument();
-      screen.debug();
     });
 
     it("Checks table is populated", async () => {
@@ -249,7 +248,6 @@ describe("===== TEMPLATES =====", () => {
       expect(
         screen.queryByText("template-detail.table")
       ).not.toBeInTheDocument();
-      screen.debug();
     });
 
     it("Checks table is populated", async () => {

--- a/resources/containers/icon-button.tsx
+++ b/resources/containers/icon-button.tsx
@@ -8,6 +8,7 @@ interface IconButtonProps {
   size?: "small" | "medium" | "large";
   name?: string;
   testId?: string;
+  title?: string,
 }
 
 const IconButton: React.FC<IconButtonProps> = ({
@@ -16,12 +17,14 @@ const IconButton: React.FC<IconButtonProps> = ({
   children,
   name,
   testId,
+  title,
   size = "medium",
 }) => {
   return (
     <button
       onClick={onClick}
       name={name}
+      title={title}
       data-testid={testId}
       className={`${icon_btn_styles.iconButton} ${icon_btn_styles[size]} ${className}`}
     >

--- a/resources/containers/styles/view-content.module.css
+++ b/resources/containers/styles/view-content.module.css
@@ -1,11 +1,12 @@
 .viewContent {
-  font-family: 'Montserrat', sans-serif;
+  font-family: "Montserrat", sans-serif;
   line-height: 1.6;
   padding: 1rem;
 }
 
-.viewContent h1, .viewContent h2, .viewContent h3 {
-  margin-bottom: 0.5rem;
+.viewContent h1,
+.viewContent h2,
+.viewContent h3 {
   font-size: 2.5vh;
   font-weight: bold;
 }
@@ -14,7 +15,8 @@
   margin-bottom: 1rem;
 }
 
-.viewContent ul, .viewContent ol {
+.viewContent ul,
+.viewContent ol {
   margin-bottom: 1rem;
   padding-left: 2rem;
 }

--- a/resources/containers/view-content-editable.tsx
+++ b/resources/containers/view-content-editable.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from "react";
+import styles from "./styles/view-content.module.css";
+import IconButton from "./icon-button";
+import { FaCopy, FaEdit, FaSave, FaTimes } from "react-icons/fa";
+import Editor from "../inputs/text-editor";
+import MessageHandler from "@/core/message-handler";
+import { useTranslation } from "react-i18next";
+
+interface ViewContentProps {
+  title: string;
+  content: string;
+  onEdit: (title: string, content: string) => void;
+}
+
+const ViewContentEditable: React.FC<ViewContentProps> = ({
+  title,
+  content,
+  onEdit,
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editingContent, setEditingContent] = useState(content);
+  const { t } = useTranslation();
+  function renderViewButtons() {
+    return (
+      <>
+        <IconButton
+          onClick={() => {
+            setEditingContent(content);
+            setIsEditing(true);
+          }}
+          size="small"
+          title={t("common.edit")}
+          testId="editable.edit"
+        >
+          <FaEdit style={{ color: "var(--primary)" }} size={10} />
+        </IconButton>
+        <IconButton
+          onClick={() => {
+            void navigator.clipboard.writeText(content);
+            MessageHandler.get().info(t("common.copy-success"));
+          }}
+          title={t("common.copy")}
+          size="small"
+          testId="editable.copy"
+        >
+          <FaCopy style={{ color: "var(--primary)" }} size={10} />
+        </IconButton>
+      </>
+    );
+  }
+  function renderEditButtons() {
+    return (
+      <>
+        <IconButton
+          onClick={() => {
+            onEdit(title, editingContent);
+            setIsEditing(false);
+          }}
+          size="small"
+          title={t("common.save")}
+          testId="editable.save"
+        >
+          <FaSave style={{ color: "var(--primary)" }} size={10} />
+        </IconButton>
+        <IconButton
+          onClick={() => {
+            setIsEditing(false);
+            setEditingContent(content);
+          }}
+          size="small"
+          title={t("common.cancel")}
+          testId="editable.cancel"
+        >
+          <FaTimes style={{ color: "var(--danger)" }} size={10} />
+        </IconButton>
+      </>
+    );
+  }
+  return (
+    <div className={styles.viewContent}>
+      <div className="editable-wrapper">
+        <div className="flex gap-4 items-center">
+          <h2 className="mr-4">{title}</h2>
+          {isEditing ? renderEditButtons() : renderViewButtons()}
+        </div>
+        {!isEditing ? (
+          <p
+            dangerouslySetInnerHTML={{
+              __html: content,
+            }}
+          ></p>
+        ) : (
+          <Editor
+            height="200px"
+            content={editingContent}
+            onContentChange={(content) => setEditingContent(content)}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ViewContentEditable;

--- a/resources/containers/view-content.tsx
+++ b/resources/containers/view-content.tsx
@@ -46,6 +46,7 @@ const ViewContent: React.FC<ViewContentProps> = ({ content }) => {
                 __html: renderObject(value as string | object),
               }}
             ></p>
+            
           </React.Fragment>
         ))}
       </div>

--- a/resources/inputs/text-editor.module.css
+++ b/resources/inputs/text-editor.module.css
@@ -1,7 +1,6 @@
 .editor {
   display: flex;
   flex-direction: column;
-  height: 57.3vh;
 }
 
 .quill {

--- a/resources/inputs/text-editor.tsx
+++ b/resources/inputs/text-editor.tsx
@@ -39,7 +39,7 @@ const Editor: React.FC<EditorProps> = ({
     "list",
     "bullet",
     "link",
-    "image",
+    // "image",
   ];
 
   const handleChange = (value: string, delta: unknown, source: string) => {
@@ -49,6 +49,11 @@ const Editor: React.FC<EditorProps> = ({
 
     onContentChange(value);
   };
+
+  // Patch, the numbers are not display as a string
+  if (!Number.isNaN(+content)) {
+    content = `<p>${content}</p>`;
+  }
 
   return (
     <div className={quill_styles.editor} style={{ height }}>

--- a/resources/inputs/text-editor.tsx
+++ b/resources/inputs/text-editor.tsx
@@ -5,8 +5,9 @@ import quill_styles from "./text-editor.module.css";
 import Spinner from "@/resources/containers/spinner";
 
 interface EditorProps {
-  content?: { [key: string]: string };
-  onContentChange: (content: { [key: string]: string }) => void;
+  content: string;
+  onContentChange: (content: string) => void;
+  height?: string;
 }
 
 const ReactQuill = dynamic(() => import("react-quill"), {
@@ -14,28 +15,31 @@ const ReactQuill = dynamic(() => import("react-quill"), {
   loading: () => <Spinner />,
 });
 
-const Editor: React.FC<EditorProps> = ({ content = {}, onContentChange }) => {
+const Editor: React.FC<EditorProps> = ({
+  content,
+  onContentChange,
+  height,
+}) => {
   const modules = {
     toolbar: [
-      [{ header: [3 /*1, 2, 3,  */, false] }],
-      // ["bold", "italic", "underline", "strike"],
-      // [{ list: "ordered" }, { list: "bullet" }],
-      // ["link", "image"],
+      [{ header: [2, 3 /* 1 */, false] }],
+      ["bold", "italic", "underline", "strike"],
+      [{ list: "ordered" }, { list: "bullet" }],
+      ["link", "image"],
       ["clean"],
     ],
   };
 
   const formats = [
     "header",
-    // TODO: Talk to the client, how we render the report?
-    // "bold",
-    // "italic",
-    // "underline",
-    // "strike",
-    // "list",
-    // "bullet",
-    // "link",
-    // "image",
+    "bold",
+    "italic",
+    "underline",
+    "strike",
+    "list",
+    "bullet",
+    "link",
+    "image",
   ];
 
   const handleChange = (value: string, delta: unknown, source: string) => {
@@ -43,51 +47,14 @@ const Editor: React.FC<EditorProps> = ({ content = {}, onContentChange }) => {
       return;
     }
 
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(value, "text/html");
-
-    const editorNodes = Array.from(doc.body.childNodes);
-    const updatedContent = editorNodes.reduce(
-      (json: Record<string, string>, node: ChildNode) => {
-        // Title
-        if (node.nodeName.toLocaleLowerCase() === "h3") {
-          if (node.textContent) {
-            json[node.textContent] = "";
-          }
-          return json;
-        }
-        // Paragraph, append to the last title
-        if (node.nodeName.toLocaleLowerCase() === "p") {
-          const lastKey = Object.keys(json).slice(-1)[0];
-          if (lastKey) {
-            json[lastKey] += node.textContent + "\n";
-          }
-          return json;
-        }
-        return json;
-      },
-      {} as Record<string, string>
-    );
-
-    onContentChange(updatedContent);
+    onContentChange(value);
   };
 
-  const htmlContent = useMemo(
-    () =>
-      Object.entries(content)
-        .map(
-          ([key, value]) =>
-            `<div><h3>${key}</h3></div><div>${value}</div><div><br/></div>`
-        )
-        .join(""),
-    [content]
-  );
-
   return (
-    <div className={quill_styles.editor}>
+    <div className={quill_styles.editor} style={{ height }}>
       <ReactQuill
         theme="snow"
-        defaultValue={htmlContent}
+        defaultValue={content}
         onChange={handleChange}
         modules={modules}
         formats={formats}


### PR DESCRIPTION
## Context

The client wants to give more editable options to the users, but they sall not break the template titles.
We allow them to edit only by blocks of content.
Also they can copy it. (But the content is HTML) 

## Test

- Create a Report
- The different sections can be copied.
- The different sections can be edited
- Priting will return the new edited content

## Proof of Concept

<img width="869" alt="image" src="https://github.com/user-attachments/assets/3c51a8fe-392a-4d99-bee5-01073dcdd95f">
<img width="873" alt="image" src="https://github.com/user-attachments/assets/ff59a4e1-87c0-4e70-ab11-c3be03cadc4d">

## Known Bugs

- The PDF can not print HTML right


